### PR TITLE
FK-221 - Force second column to be treated as string in Excel

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -41,7 +41,7 @@ ORDER BY orders.created_at ASC;"
       p.workbook.add_worksheet(:name => 'Fjärrkontrollen - beställningar') do |sheet|
         sheet.add_row(result.columns.map{ |column| export_column_name_mappings(column) })
         result.rows.each do |row|
-          sheet.add_row(row)
+          sheet.add_row(row, types: [nil, :string])
         end
       end
       return p


### PR DESCRIPTION
Order number looks like a numeric value, and Excel therefor loads it as such. There is not enough floating point precision in Excel to represent the full value.

This changes that column to be treated as string instead, since the order number isn't really a number that should be used in calculations.